### PR TITLE
Resume countdown after suspend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ debian/upstream/
 **.qm
 **.stash
 **.pro.user
+build
+.qtcreator
+shutdown-qapps.pro.user*

--- a/qshutdown/src/calendar.cpp
+++ b/qshutdown/src/calendar.cpp
@@ -19,6 +19,48 @@
 #include <QPushButton>
 #include <QFile>
 #include <QDir>
+#include <QDebug>
+
+namespace {
+
+int defaultWeeklyActionIndex(){
+     QSettings settings;
+     int actionIndex = settings.value("Power/comboBox", 0).toInt();
+     if(actionIndex < 0 || actionIndex > 3)
+       actionIndex = 0;
+     return actionIndex;
+}
+
+void updateWeekDayItems(const QList<WeekDayItem *> &addItemList,
+                        const QList<WeekDayItem *> &removeItemList){
+     const int defaultAction = defaultWeeklyActionIndex();
+
+     foreach(WeekDayItem *item, addItemList){
+       const bool wasVisible = item->isVisible();
+       item->setVisible(true);
+       item->setEnabled(true);
+       if(!wasVisible)
+         item->comboBox->setCurrentIndex(defaultAction);
+     }
+     foreach(WeekDayItem *item, removeItemList){
+       item->setVisible(false);
+       item->setEnabled(false);
+       item->comboBox->setCurrentIndex(defaultAction);
+     }
+}
+
+void saveDayMethods(QSettings *settings, const QString &day,
+                    const QList<WeekDayItem *> &items, int activeCount){
+     for(int i = 0; i < items.count(); ++i){
+       QString key = QString("%1/method_%2").arg(day).arg(i + 1);
+       if(i < activeCount)
+         settings->setValue(key, items[i]->comboBox->currentIndex());
+       else
+         settings->remove(key);
+     }
+}
+
+}
 
 Calendar::Calendar(QWidget *parent): QDialog(parent){
 
@@ -175,6 +217,7 @@ Calendar::~Calendar(){ delete settings; }
 void Calendar::getDate(QDate date){ calendarDate.setDate(date); }
 
 void Calendar::setDate(){
+     qDebug() << "[setDate] Called at" << QDateTime::currentDateTime();
      if(calendarWidget->selectedDate() != QDate::currentDate())
         calendarDate.setDate(calendarWidget->selectedDate());
      if(!weekly->isChecked() && calendarDate.isValid()
@@ -182,10 +225,14 @@ void Calendar::setDate(){
        setCalendarDate = calendarDate; //don't touch calendarDate!
      else
        setCalendarDate = QDateTime();
-     if(weekly->isChecked())
+     if(weekly->isChecked()){
+       qDebug() << "[setDate] Weekly is checked, calling getSortedAndActivatedDays()";
        getSortedAndActivatedDays();
-     else
+     }
+     else{
+       qDebug() << "[setDate] Weekly is NOT checked, clearing setWeeklyDate";
        setWeeklyDate = QDateTime();
+     }
 
      aDateWasSet();
 }
@@ -208,6 +255,7 @@ void Calendar::getSortedAndActivatedDays(){
        activatedDays[6] = Qt::Sunday;
 
      int todaysDayOfWeek = QDate::currentDate().dayOfWeek();
+     qDebug() << "[getSortedAndActivatedDays] todaysDayOfWeek=" << todaysDayOfWeek << "(" << QDate::currentDate().toString("dddd") << ")";
 
      QList<int> calculatedDay;
      for(int i=0; i < 7; i++){
@@ -216,17 +264,21 @@ void Calendar::getSortedAndActivatedDays(){
          if(x < 0)
            x += 7;
          calculatedDay << x;
+         qDebug() << "[getSortedAndActivatedDays]   day offset +" << x << "for day of week" << activatedDays[i];
        }
      } //note that all calculated days are in the future. Only if it is today, the time can be in the past!
 
      if(calculatedDay.isEmpty()){
+       qDebug() << "[getSortedAndActivatedDays] No activated days found";
        setWeeklyDate = QDateTime();
        aDateWasSet();
        return;
      }
 
      std::sort(calculatedDay.begin(), calculatedDay.end());
+     qDebug() << "[getSortedAndActivatedDays] Sorted calculated days:" << calculatedDay;
      setWeeklyDate = QDateTime::currentDateTime().addDays(calculatedDay[0]);
+     qDebug() << "[getSortedAndActivatedDays] setWeeklyDate initialized to" << setWeeklyDate << "(today +" << calculatedDay[0] << "days)";
 
      getNearestTime(calculatedDay);
 }
@@ -234,79 +286,94 @@ void Calendar::getSortedAndActivatedDays(){
 void Calendar::getNearestTime(QList<int> calculatedDay){
      QList<QTime> times = getSortedTimes();
 
-     if(QDateTime(setWeeklyDate.date(),times[0]) > QDateTime::currentDateTime())
+     qDebug() << "[getNearestTime] After getSortedTimes():"
+              << "day of week=" << setWeeklyDate.date().dayOfWeek()
+              << "times count=" << times.count()
+              << "times=" << times
+              << "setWeeklyDate=" << setWeeklyDate
+              << "current time=" << QDateTime::currentDateTime();
+
+     // Guard: if no enabled times were found for the chosen day (can happen
+     // if widget enabled-state and spin value got out of sync, e.g. on
+     // startup before all parents are enabled), bail out cleanly instead of
+     // crashing on times[0].
+     if(times.isEmpty()){
+       qDebug() << "[getNearestTime] Times list is empty, bailing out";
+       setWeeklyDate = QDateTime();
+       aDateWasSet();
+       return;
+     }
+
+     if(QDateTime(setWeeklyDate.date(),times[0]) > QDateTime::currentDateTime()){
+       qDebug() << "[getNearestTime] First time" << times[0] << "is in future, using it";
        setWeeklyDate.setTime(times[0]);
+     }
      else{
        int i = 0; //first index for the list of the sorted times
-       while((QDateTime(setWeeklyDate.date(),times[i]) <= QDateTime::currentDateTime())
-             && (i < times.count())){ //as long as we have a next position and the time is in the past: i+1
+       qDebug() << "[getNearestTime] First time is in past, searching for next future time...";
+       // Note: bounds check MUST come before times[i] access (short-circuit
+       // evaluation), otherwise the last iteration reads past the end.
+       while((i < times.count())
+             && (QDateTime(setWeeklyDate.date(),times[i]) <= QDateTime::currentDateTime())){
+         qDebug() << "[getNearestTime]   times[" << i << "]=" << times[i] << "is in past, continuing";
          ++i;
        } //at this point we have either a matching time or nothing. Nothing would be bad...
-       if(i < times.count()) //there has been a matching time...
+       if(i < times.count()){ //there has been a matching time...
+         qDebug() << "[getNearestTime] Found future time at index" << i << ":" << times[i];
          setWeeklyDate.setTime(times[i]);
+       }
        if(i >= times.count()){ //there was no matching time, but there still might be one on another day.
+         qDebug() << "[getNearestTime] No more times today (i=" << i << "), checking next days...";
          if(calculatedDay.count() > 1){ //if there is at least another day...
+           qDebug() << "[getNearestTime]   Using next day (calculatedDay[1]=" << calculatedDay[1] << ")";
            setWeeklyDate = QDateTime::currentDateTime().addDays(calculatedDay[1]); //take another day...
            times = getSortedTimes();      //and get the new times list.
+           if(times.isEmpty()){
+             qDebug() << "[getNearestTime]   Times empty for next day, bailing";
+             setWeeklyDate = QDateTime();
+             aDateWasSet();
+             return;
+           }
+           qDebug() << "[getNearestTime]   Using first time of next day:" << times[0];
            setWeeklyDate.setTime(times[0]); //the first time setting will do.
          }
          else{ // there is no other day => +7
+           qDebug() << "[getNearestTime]   No more days this week, using same day next week +" << calculatedDay[0];
            setWeeklyDate = QDateTime::currentDateTime().addDays(7);
            setWeeklyDate.setTime(times[0]);
          }
        }
      }
+     qDebug() << "[getNearestTime] Final result: setWeeklyDate=" << setWeeklyDate;
 }
 
 QList<QTime> Calendar::getSortedTimes(){
      QList<QTime> times;
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Monday){ //Which day of week is the choosen day?
-       foreach(WeekDayItem *item, *mondayItems){
-         if(item->isEnabled()){ //get all items if they are visible/enabled.
-           times << item->timeEdit->time();
-         }
-       }
-     }
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Tuesday){
-       foreach(WeekDayItem *item, *tuesdayItems){
-         if(item->isEnabled()){
-           times << item->timeEdit->time();
-         }
-       }
-     }
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Wednesday){
-       foreach(WeekDayItem *item, *wednesdayItems){
-         if(item->isEnabled()){
-           times << item->timeEdit->time();
-         }
-       }
-     }
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Thursday){
-       foreach(WeekDayItem *item, *thursdayItems){
-         if(item->isEnabled()){
-           times << item->timeEdit->time();
-         }
-       }
-     }
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Friday){
-       foreach(WeekDayItem *item, *fridayItems){
-         if(item->isEnabled()){
-           times << item->timeEdit->time();
-         }
-       }
-     }
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Saturday){
-       foreach(WeekDayItem *item, *saturdayItems){
-         if(item->isEnabled()){
-           times << item->timeEdit->time();
-         }
-       }
-     }
-     if(setWeeklyDate.date().dayOfWeek() == Qt::Sunday){
-       foreach(WeekDayItem *item, *sundayItems){
-         if(item->isEnabled()){
-           times << item->timeEdit->time();
-         }
+     // Use spin->value() as the authoritative count of active items for the
+     // day, instead of item->isEnabled(). isEnabled() returns false whenever
+     // ANY ancestor widget is disabled (e.g. scrollAreaWidgetContents during
+     // startup before weekly toggling has propagated), which would yield an
+     // empty list even though the saved spin values say items are active.
+     int dow = setWeeklyDate.date().dayOfWeek();
+     QList<WeekDayItem *> *items = nullptr;
+     int count = 0;
+     QString dayName;
+     if(dow == Qt::Monday){       items = mondayItems;    count = mon->spin->value(); dayName = "Monday"; }
+     else if(dow == Qt::Tuesday){ items = tuesdayItems;   count = tue->spin->value(); dayName = "Tuesday"; }
+     else if(dow == Qt::Wednesday){ items = wednesdayItems; count = wed->spin->value(); dayName = "Wednesday"; }
+     else if(dow == Qt::Thursday){items = thursdayItems;  count = thu->spin->value(); dayName = "Thursday"; }
+     else if(dow == Qt::Friday){  items = fridayItems;    count = fri->spin->value(); dayName = "Friday"; }
+     else if(dow == Qt::Saturday){items = saturdayItems;  count = sat->spin->value(); dayName = "Saturday"; }
+     else if(dow == Qt::Sunday){  items = sundayItems;    count = sun->spin->value(); dayName = "Sunday"; }
+
+     qDebug() << "[getSortedTimes] day=" << dayName << "dow=" << dow << "spin->value()=" << count << "items->size()=" << (items ? items->size() : 0);
+
+     if(items){
+       int n = qMin(count, items->size());
+       for(int i = 0; i < n; ++i){
+         QTime t = items->at(i)->timeEdit->time();
+         times << t;
+         qDebug() << "[getSortedTimes]   added time[" << i << "]=" << t;
        }
      }
 
@@ -318,6 +385,7 @@ QList<QTime> Calendar::getSortedTimes(){
        }
      }
 
+     qDebug() << "[getSortedTimes] Final sorted times:" << times;
      return times;
 }
 
@@ -366,14 +434,7 @@ void Calendar::monday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::tuesday_addTimeEditAndActionBox(int i){
@@ -406,14 +467,7 @@ void Calendar::tuesday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::wednesday_addTimeEditAndActionBox(int i){
@@ -446,14 +500,7 @@ void Calendar::wednesday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::thursday_addTimeEditAndActionBox(int i){
@@ -486,14 +533,7 @@ void Calendar::thursday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::friday_addTimeEditAndActionBox(int i){
@@ -526,14 +566,7 @@ void Calendar::friday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::saturday_addTimeEditAndActionBox(int i){
@@ -566,14 +599,7 @@ void Calendar::saturday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::sunday_addTimeEditAndActionBox(int i){
@@ -606,14 +632,7 @@ void Calendar::sunday_addTimeEditAndActionBox(int i){
        default:;
      }
 
-     foreach(WeekDayItem *item, addItemList){
-       item->setVisible(true);
-       item->setEnabled(true);
-     }
-     foreach(WeekDayItem *item, removeItemList){
-       item->setVisible(false);
-       item->setEnabled(false);
-     }
+     updateWeekDayItems(addItemList, removeItemList);
 }
 
 void Calendar::saveToConfFile(){
@@ -627,81 +646,66 @@ void Calendar::saveToConfFile(){
        settings->setValue("Monday/time_3",mon3->timeEdit->time().toString());
        settings->setValue("Monday/time_4",mon4->timeEdit->time().toString());
        settings->setValue("Monday/time_5",mon5->timeEdit->time().toString());
-       settings->setValue("Monday/method_1",mon1->comboBox->currentIndex());
-       settings->setValue("Monday/method_2",mon2->comboBox->currentIndex());
-       settings->setValue("Monday/method_3",mon3->comboBox->currentIndex());
-       settings->setValue("Monday/method_4",mon4->comboBox->currentIndex());
-       settings->setValue("Monday/method_5",mon5->comboBox->currentIndex());
+       saveDayMethods(settings, "Monday", *mondayItems, mon->spin->value());
        settings->setValue("Tuesday/number_of_times",tue->spin->value());
        settings->setValue("Tuesday/time_1",tue1->timeEdit->time().toString());
        settings->setValue("Tuesday/time_2",tue2->timeEdit->time().toString());
        settings->setValue("Tuesday/time_3",tue3->timeEdit->time().toString());
        settings->setValue("Tuesday/time_4",tue4->timeEdit->time().toString());
        settings->setValue("Tuesday/time_5",tue5->timeEdit->time().toString());
-       settings->setValue("Tuesday/method_1",tue1->comboBox->currentIndex());
-       settings->setValue("Tuesday/method_2",tue2->comboBox->currentIndex());
-       settings->setValue("Tuesday/method_3",tue3->comboBox->currentIndex());
-       settings->setValue("Tuesday/method_4",tue4->comboBox->currentIndex());
-       settings->setValue("Tuesday/method_5",tue5->comboBox->currentIndex());
+       saveDayMethods(settings, "Tuesday", *tuesdayItems, tue->spin->value());
        settings->setValue("Wednesday/number_of_times",wed->spin->value());
        settings->setValue("Wednesday/time_1",wed1->timeEdit->time().toString());
        settings->setValue("Wednesday/time_2",wed2->timeEdit->time().toString());
        settings->setValue("Wednesday/time_3",wed3->timeEdit->time().toString());
        settings->setValue("Wednesday/time_4",wed4->timeEdit->time().toString());
        settings->setValue("Wednesday/time_5",wed5->timeEdit->time().toString());
-       settings->setValue("Wednesday/method_1",wed1->comboBox->currentIndex());
-       settings->setValue("Wednesday/method_2",wed2->comboBox->currentIndex());
-       settings->setValue("Wednesday/method_3",wed3->comboBox->currentIndex());
-       settings->setValue("Wednesday/method_4",wed4->comboBox->currentIndex());
-       settings->setValue("Wednesday/method_5",wed5->comboBox->currentIndex());
+       saveDayMethods(settings, "Wednesday", *wednesdayItems, wed->spin->value());
        settings->setValue("Thursday/number_of_times",thu->spin->value());
        settings->setValue("Thursday/time_1",thu1->timeEdit->time().toString());
        settings->setValue("Thursday/time_2",thu2->timeEdit->time().toString());
        settings->setValue("Thursday/time_3",thu3->timeEdit->time().toString());
        settings->setValue("Thursday/time_4",thu4->timeEdit->time().toString());
        settings->setValue("Thursday/time_5",thu5->timeEdit->time().toString());
-       settings->setValue("Thursday/method_1",thu1->comboBox->currentIndex());
-       settings->setValue("Thursday/method_2",thu2->comboBox->currentIndex());
-       settings->setValue("Thursday/method_3",thu3->comboBox->currentIndex());
-       settings->setValue("Thursday/method_4",thu4->comboBox->currentIndex());
-       settings->setValue("Thursday/method_5",thu5->comboBox->currentIndex());
+       saveDayMethods(settings, "Thursday", *thursdayItems, thu->spin->value());
        settings->setValue("Friday/number_of_times",fri->spin->value());
        settings->setValue("Friday/time_1",fri1->timeEdit->time().toString());
        settings->setValue("Friday/time_2",fri2->timeEdit->time().toString());
        settings->setValue("Friday/time_3",fri3->timeEdit->time().toString());
        settings->setValue("Friday/time_4",fri4->timeEdit->time().toString());
        settings->setValue("Friday/time_5",fri5->timeEdit->time().toString());
-       settings->setValue("Friday/method_1",fri1->comboBox->currentIndex());
-       settings->setValue("Friday/method_2",fri2->comboBox->currentIndex());
-       settings->setValue("Friday/method_3",fri3->comboBox->currentIndex());
-       settings->setValue("Friday/method_4",fri4->comboBox->currentIndex());
-       settings->setValue("Friday/method_5",fri5->comboBox->currentIndex());
+       saveDayMethods(settings, "Friday", *fridayItems, fri->spin->value());
        settings->setValue("Saturday/number_of_times",sat->spin->value());
        settings->setValue("Saturday/time_1",sat1->timeEdit->time().toString());
        settings->setValue("Saturday/time_2",sat2->timeEdit->time().toString());
        settings->setValue("Saturday/time_3",sat3->timeEdit->time().toString());
        settings->setValue("Saturday/time_4",sat4->timeEdit->time().toString());
        settings->setValue("Saturday/time_5",sat5->timeEdit->time().toString());
-       settings->setValue("Saturday/method_1",sat1->comboBox->currentIndex());
-       settings->setValue("Saturday/method_2",sat2->comboBox->currentIndex());
-       settings->setValue("Saturday/method_3",sat3->comboBox->currentIndex());
-       settings->setValue("Saturday/method_4",sat4->comboBox->currentIndex());
-       settings->setValue("Saturday/method_5",sat5->comboBox->currentIndex());
+       saveDayMethods(settings, "Saturday", *saturdayItems, sat->spin->value());
        settings->setValue("Sunday/number_of_times",sun->spin->value());
        settings->setValue("Sunday/time_1",sun1->timeEdit->time().toString());
        settings->setValue("Sunday/time_2",sun2->timeEdit->time().toString());
        settings->setValue("Sunday/time_3",sun3->timeEdit->time().toString());
        settings->setValue("Sunday/time_4",sun4->timeEdit->time().toString());
        settings->setValue("Sunday/time_5",sun5->timeEdit->time().toString());
-       settings->setValue("Sunday/method_1",sun1->comboBox->currentIndex());
-       settings->setValue("Sunday/method_2",sun2->comboBox->currentIndex());
-       settings->setValue("Sunday/method_3",sun3->comboBox->currentIndex());
-       settings->setValue("Sunday/method_4",sun4->comboBox->currentIndex());
-       settings->setValue("Sunday/method_5",sun5->comboBox->currentIndex());
+       saveDayMethods(settings, "Sunday", *sundayItems, sun->spin->value());
      }
 }
 
 void Calendar::loadSettings(){
+     // Helper: only override the per-item action comboBox if a saved value
+     // actually exists. Otherwise leave it at the user's "default shutdown
+     // type" from preferences (set by WeekDayItem's constructor).
+     auto loadMethod = [this](QComboBox *box, const QString &key){
+       if(settings->contains(key))
+         box->setCurrentIndex(settings->value(key).toInt());
+     };
+     auto resetInactiveMethods = [](const QList<WeekDayItem *> &items, int activeCount){
+       const int defaultAction = defaultWeeklyActionIndex();
+       for(int i = activeCount; i < items.count(); ++i)
+         items[i]->comboBox->setCurrentIndex(defaultAction);
+     };
+
      resize(settings->value("MainWindow/size",QSize(325,360)).toSize());
      tabWidget->setCurrentIndex(settings->value("Calendar_or_weekly",0).toInt());
      weekly->setChecked(settings->value("Weekly_is_set", false).toBool());
@@ -713,75 +717,82 @@ void Calendar::loadSettings(){
      mon3->timeEdit->setTime(QTime::fromString(settings->value("Monday/time_3","22:00:00").toString(), "hh:mm:ss"));
      mon4->timeEdit->setTime(QTime::fromString(settings->value("Monday/time_4","22:00:00").toString(), "hh:mm:ss"));
      mon5->timeEdit->setTime(QTime::fromString(settings->value("Monday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     mon1->comboBox->setCurrentIndex(settings->value("Monday/method_1",0).toInt());
-     mon2->comboBox->setCurrentIndex(settings->value("Monday/method_2",0).toInt());
-     mon3->comboBox->setCurrentIndex(settings->value("Monday/method_3",0).toInt());
-     mon4->comboBox->setCurrentIndex(settings->value("Monday/method_4",0).toInt());
-     mon5->comboBox->setCurrentIndex(settings->value("Monday/method_5",0).toInt());
+     loadMethod(mon1->comboBox, "Monday/method_1");
+     loadMethod(mon2->comboBox, "Monday/method_2");
+     loadMethod(mon3->comboBox, "Monday/method_3");
+     loadMethod(mon4->comboBox, "Monday/method_4");
+     loadMethod(mon5->comboBox, "Monday/method_5");
+    resetInactiveMethods(*mondayItems, mon->spin->value());
      tue->spin->setValue(settings->value("Tuesday/number_of_times",0).toInt());
      tue1->timeEdit->setTime(QTime::fromString(settings->value("Tuesday/time_1","22:00:00").toString(), "hh:mm:ss"));
      tue2->timeEdit->setTime(QTime::fromString(settings->value("Tuesday/time_2","22:00:00").toString(), "hh:mm:ss"));
      tue3->timeEdit->setTime(QTime::fromString(settings->value("Tuesday/time_3","22:00:00").toString(), "hh:mm:ss"));
      tue4->timeEdit->setTime(QTime::fromString(settings->value("Tuesday/time_4","22:00:00").toString(), "hh:mm:ss"));
      tue5->timeEdit->setTime(QTime::fromString(settings->value("Tuesday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     tue1->comboBox->setCurrentIndex(settings->value("Tuesday/method_1",0).toInt());
-     tue2->comboBox->setCurrentIndex(settings->value("Tuesday/method_2",0).toInt());
-     tue3->comboBox->setCurrentIndex(settings->value("Tuesday/method_3",0).toInt());
-     tue4->comboBox->setCurrentIndex(settings->value("Tuesday/method_4",0).toInt());
-     tue5->comboBox->setCurrentIndex(settings->value("Tuesday/method_5",0).toInt());
+     loadMethod(tue1->comboBox, "Tuesday/method_1");
+     loadMethod(tue2->comboBox, "Tuesday/method_2");
+     loadMethod(tue3->comboBox, "Tuesday/method_3");
+     loadMethod(tue4->comboBox, "Tuesday/method_4");
+     loadMethod(tue5->comboBox, "Tuesday/method_5");
+    resetInactiveMethods(*tuesdayItems, tue->spin->value());
      wed->spin->setValue(settings->value("Wednesday/number_of_times",0).toInt());
      wed1->timeEdit->setTime(QTime::fromString(settings->value("Wednesday/time_1","22:00:00").toString(), "hh:mm:ss"));
      wed2->timeEdit->setTime(QTime::fromString(settings->value("Wednesday/time_2","22:00:00").toString(), "hh:mm:ss"));
      wed3->timeEdit->setTime(QTime::fromString(settings->value("Wednesday/time_3","22:00:00").toString(), "hh:mm:ss"));
      wed4->timeEdit->setTime(QTime::fromString(settings->value("Wednesday/time_4","22:00:00").toString(), "hh:mm:ss"));
      wed5->timeEdit->setTime(QTime::fromString(settings->value("Wednesday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     wed1->comboBox->setCurrentIndex(settings->value("Wednesday/method_1",0).toInt());
-     wed2->comboBox->setCurrentIndex(settings->value("Wednesday/method_2",0).toInt());
-     wed3->comboBox->setCurrentIndex(settings->value("Wednesday/method_3",0).toInt());
-     wed4->comboBox->setCurrentIndex(settings->value("Wednesday/method_4",0).toInt());
-     wed5->comboBox->setCurrentIndex(settings->value("Wednesday/method_5",0).toInt());
+     loadMethod(wed1->comboBox, "Wednesday/method_1");
+     loadMethod(wed2->comboBox, "Wednesday/method_2");
+     loadMethod(wed3->comboBox, "Wednesday/method_3");
+     loadMethod(wed4->comboBox, "Wednesday/method_4");
+     loadMethod(wed5->comboBox, "Wednesday/method_5");
+    resetInactiveMethods(*wednesdayItems, wed->spin->value());
      thu->spin->setValue(settings->value("Thursday/number_of_times",0).toInt());
      thu1->timeEdit->setTime(QTime::fromString(settings->value("Thursday/time_1","22:00:00").toString(), "hh:mm:ss"));
      thu2->timeEdit->setTime(QTime::fromString(settings->value("Thursday/time_2","22:00:00").toString(), "hh:mm:ss"));
      thu3->timeEdit->setTime(QTime::fromString(settings->value("Thursday/time_3","22:00:00").toString(), "hh:mm:ss"));
      thu4->timeEdit->setTime(QTime::fromString(settings->value("Thursday/time_4","22:00:00").toString(), "hh:mm:ss"));
      thu5->timeEdit->setTime(QTime::fromString(settings->value("Thursday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     thu1->comboBox->setCurrentIndex(settings->value("Thursday/method_1",0).toInt());
-     thu2->comboBox->setCurrentIndex(settings->value("Thursday/method_2",0).toInt());
-     thu3->comboBox->setCurrentIndex(settings->value("Thursday/method_3",0).toInt());
-     thu4->comboBox->setCurrentIndex(settings->value("Thursday/method_4",0).toInt());
-     thu5->comboBox->setCurrentIndex(settings->value("Thursday/method_5",0).toInt());
+     loadMethod(thu1->comboBox, "Thursday/method_1");
+     loadMethod(thu2->comboBox, "Thursday/method_2");
+     loadMethod(thu3->comboBox, "Thursday/method_3");
+     loadMethod(thu4->comboBox, "Thursday/method_4");
+     loadMethod(thu5->comboBox, "Thursday/method_5");
+    resetInactiveMethods(*thursdayItems, thu->spin->value());
      fri->spin->setValue(settings->value("Friday/number_of_times",0).toInt());
      fri1->timeEdit->setTime(QTime::fromString(settings->value("Friday/time_1","22:00:00").toString(), "hh:mm:ss"));
      fri2->timeEdit->setTime(QTime::fromString(settings->value("Friday/time_2","22:00:00").toString(), "hh:mm:ss"));
      fri3->timeEdit->setTime(QTime::fromString(settings->value("Friday/time_3","22:00:00").toString(), "hh:mm:ss"));
      fri4->timeEdit->setTime(QTime::fromString(settings->value("Friday/time_4","22:00:00").toString(), "hh:mm:ss"));
      fri5->timeEdit->setTime(QTime::fromString(settings->value("Friday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     fri1->comboBox->setCurrentIndex(settings->value("Friday/method_1",0).toInt());
-     fri2->comboBox->setCurrentIndex(settings->value("Friday/method_2",0).toInt());
-     fri3->comboBox->setCurrentIndex(settings->value("Friday/method_3",0).toInt());
-     fri4->comboBox->setCurrentIndex(settings->value("Friday/method_4",0).toInt());
-     fri5->comboBox->setCurrentIndex(settings->value("Friday/method_5",0).toInt());
+     loadMethod(fri1->comboBox, "Friday/method_1");
+     loadMethod(fri2->comboBox, "Friday/method_2");
+     loadMethod(fri3->comboBox, "Friday/method_3");
+     loadMethod(fri4->comboBox, "Friday/method_4");
+     loadMethod(fri5->comboBox, "Friday/method_5");
+    resetInactiveMethods(*fridayItems, fri->spin->value());
      sat->spin->setValue(settings->value("Saturday/number_of_times",0).toInt());
      sat1->timeEdit->setTime(QTime::fromString(settings->value("Saturday/time_1","22:00:00").toString(), "hh:mm:ss"));
      sat2->timeEdit->setTime(QTime::fromString(settings->value("Saturday/time_2","22:00:00").toString(), "hh:mm:ss"));
      sat3->timeEdit->setTime(QTime::fromString(settings->value("Saturday/time_3","22:00:00").toString(), "hh:mm:ss"));
      sat4->timeEdit->setTime(QTime::fromString(settings->value("Saturday/time_4","22:00:00").toString(), "hh:mm:ss"));
      sat5->timeEdit->setTime(QTime::fromString(settings->value("Saturday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     sat1->comboBox->setCurrentIndex(settings->value("Saturday/method_1",0).toInt());
-     sat2->comboBox->setCurrentIndex(settings->value("Saturday/method_2",0).toInt());
-     sat3->comboBox->setCurrentIndex(settings->value("Saturday/method_3",0).toInt());
-     sat4->comboBox->setCurrentIndex(settings->value("Saturday/method_4",0).toInt());
-     sat5->comboBox->setCurrentIndex(settings->value("Saturday/method_5",0).toInt());
+     loadMethod(sat1->comboBox, "Saturday/method_1");
+     loadMethod(sat2->comboBox, "Saturday/method_2");
+     loadMethod(sat3->comboBox, "Saturday/method_3");
+     loadMethod(sat4->comboBox, "Saturday/method_4");
+     loadMethod(sat5->comboBox, "Saturday/method_5");
+    resetInactiveMethods(*saturdayItems, sat->spin->value());
      sun->spin->setValue(settings->value("Sunday/number_of_times",0).toInt());
      sun1->timeEdit->setTime(QTime::fromString(settings->value("Sunday/time_1","22:00:00").toString(), "hh:mm:ss"));
      sun2->timeEdit->setTime(QTime::fromString(settings->value("Sunday/time_2","22:00:00").toString(), "hh:mm:ss"));
      sun3->timeEdit->setTime(QTime::fromString(settings->value("Sunday/time_3","22:00:00").toString(), "hh:mm:ss"));
      sun4->timeEdit->setTime(QTime::fromString(settings->value("Sunday/time_4","22:00:00").toString(), "hh:mm:ss"));
      sun5->timeEdit->setTime(QTime::fromString(settings->value("Sunday/time_5","22:00:00").toString(), "hh:mm:ss"));
-     sun1->comboBox->setCurrentIndex(settings->value("Sunday/method_1",0).toInt());
-     sun2->comboBox->setCurrentIndex(settings->value("Sunday/method_2",0).toInt());
-     sun3->comboBox->setCurrentIndex(settings->value("Sunday/method_3",0).toInt());
-     sun4->comboBox->setCurrentIndex(settings->value("Sunday/method_4",0).toInt());
-     sun5->comboBox->setCurrentIndex(settings->value("Sunday/method_5",0).toInt());
+     loadMethod(sun1->comboBox, "Sunday/method_1");
+     loadMethod(sun2->comboBox, "Sunday/method_2");
+     loadMethod(sun3->comboBox, "Sunday/method_3");
+     loadMethod(sun4->comboBox, "Sunday/method_4");
+     loadMethod(sun5->comboBox, "Sunday/method_5");
+    resetInactiveMethods(*sundayItems, sun->spin->value());
 }

--- a/qshutdown/src/calendar.cpp
+++ b/qshutdown/src/calendar.cpp
@@ -155,7 +155,15 @@ Calendar::Calendar(QWidget *parent): QDialog(parent){
      connect(sat->spin, SIGNAL(valueChanged(int)), this, SLOT(saturday_addTimeEditAndActionBox(int)));
      connect(sun->spin, SIGNAL(valueChanged(int)), this, SLOT(sunday_addTimeEditAndActionBox(int)));
 
-     if(!QFile::exists(file))
+     // Use the actual QSettings backing-file path so we only write defaults
+     // when no settings file exists yet. The 'file' member was previously
+     // never assigned, which made QFile::exists(file) always false and caused
+     // saveToConfFile() to overwrite saved weekly settings on every startup
+     // with the widgets' default (empty) values.
+     file = settings->fileName();
+
+     if(!QFile::exists(file)
+        || !settings->contains("Weekly_is_set"))
        saveToConfFile();
      else
        loadSettings();

--- a/qshutdown/src/calendar.cpp
+++ b/qshutdown/src/calendar.cpp
@@ -217,7 +217,7 @@ Calendar::~Calendar(){ delete settings; }
 void Calendar::getDate(QDate date){ calendarDate.setDate(date); }
 
 void Calendar::setDate(){
-     qDebug() << "[setDate] Called at" << QDateTime::currentDateTime();
+       qDebug() << "Calendar::setDate(): Called at" << QDateTime::currentDateTime();
      if(calendarWidget->selectedDate() != QDate::currentDate())
         calendarDate.setDate(calendarWidget->selectedDate());
      if(!weekly->isChecked() && calendarDate.isValid()
@@ -226,11 +226,11 @@ void Calendar::setDate(){
      else
        setCalendarDate = QDateTime();
      if(weekly->isChecked()){
-       qDebug() << "[setDate] Weekly is checked, calling getSortedAndActivatedDays()";
+       qDebug() << "Calendar::setDate(): Weekly is checked, calling getSortedAndActivatedDays()";
        getSortedAndActivatedDays();
      }
      else{
-       qDebug() << "[setDate] Weekly is NOT checked, clearing setWeeklyDate";
+       qDebug() << "Calendar::setDate(): Weekly is not checked, clearing setWeeklyDate";
        setWeeklyDate = QDateTime();
      }
 
@@ -255,7 +255,7 @@ void Calendar::getSortedAndActivatedDays(){
        activatedDays[6] = Qt::Sunday;
 
      int todaysDayOfWeek = QDate::currentDate().dayOfWeek();
-     qDebug() << "[getSortedAndActivatedDays] todaysDayOfWeek=" << todaysDayOfWeek << "(" << QDate::currentDate().toString("dddd") << ")";
+     qDebug() << "Calendar::getSortedAndActivatedDays(): todaysDayOfWeek=" << todaysDayOfWeek << "(" << QDate::currentDate().toString("dddd") << ")";
 
      QList<int> calculatedDay;
      for(int i=0; i < 7; i++){
@@ -264,21 +264,21 @@ void Calendar::getSortedAndActivatedDays(){
          if(x < 0)
            x += 7;
          calculatedDay << x;
-         qDebug() << "[getSortedAndActivatedDays]   day offset +" << x << "for day of week" << activatedDays[i];
+         qDebug() << "Calendar::getSortedAndActivatedDays():   day offset +" << x << "for day of week" << activatedDays[i];
        }
      } //note that all calculated days are in the future. Only if it is today, the time can be in the past!
 
      if(calculatedDay.isEmpty()){
-       qDebug() << "[getSortedAndActivatedDays] No activated days found";
+       qDebug() << "Calendar::getSortedAndActivatedDays(): No activated days found";
        setWeeklyDate = QDateTime();
        aDateWasSet();
        return;
      }
 
      std::sort(calculatedDay.begin(), calculatedDay.end());
-     qDebug() << "[getSortedAndActivatedDays] Sorted calculated days:" << calculatedDay;
+     qDebug() << "Calendar::getSortedAndActivatedDays(): Sorted calculated days:" << calculatedDay;
      setWeeklyDate = QDateTime::currentDateTime().addDays(calculatedDay[0]);
-     qDebug() << "[getSortedAndActivatedDays] setWeeklyDate initialized to" << setWeeklyDate << "(today +" << calculatedDay[0] << "days)";
+     qDebug() << "Calendar::getSortedAndActivatedDays(): setWeeklyDate initialized to" << setWeeklyDate << "(today +" << calculatedDay[0] << "days)";
 
      getNearestTime(calculatedDay);
 }
@@ -286,7 +286,7 @@ void Calendar::getSortedAndActivatedDays(){
 void Calendar::getNearestTime(QList<int> calculatedDay){
      QList<QTime> times = getSortedTimes();
 
-     qDebug() << "[getNearestTime] After getSortedTimes():"
+     qDebug() << "Calendar::getNearestTime(): After getSortedTimes():"
               << "day of week=" << setWeeklyDate.date().dayOfWeek()
               << "times count=" << times.count()
               << "times=" << times
@@ -298,53 +298,53 @@ void Calendar::getNearestTime(QList<int> calculatedDay){
      // startup before all parents are enabled), bail out cleanly instead of
      // crashing on times[0].
      if(times.isEmpty()){
-       qDebug() << "[getNearestTime] Times list is empty, bailing out";
+       qDebug() << "Calendar::getNearestTime(): Times list is empty, bailing out";
        setWeeklyDate = QDateTime();
        aDateWasSet();
        return;
      }
 
      if(QDateTime(setWeeklyDate.date(),times[0]) > QDateTime::currentDateTime()){
-       qDebug() << "[getNearestTime] First time" << times[0] << "is in future, using it";
+       qDebug() << "Calendar::getNearestTime(): First time" << times[0] << "is in future, using it";
        setWeeklyDate.setTime(times[0]);
      }
      else{
        int i = 0; //first index for the list of the sorted times
-       qDebug() << "[getNearestTime] First time is in past, searching for next future time...";
+       qDebug() << "Calendar::getNearestTime(): First time is in past, searching for next future time...";
        // Note: bounds check MUST come before times[i] access (short-circuit
        // evaluation), otherwise the last iteration reads past the end.
        while((i < times.count())
              && (QDateTime(setWeeklyDate.date(),times[i]) <= QDateTime::currentDateTime())){
-         qDebug() << "[getNearestTime]   times[" << i << "]=" << times[i] << "is in past, continuing";
+         qDebug() << "Calendar::getNearestTime():   times[" << i << "]=" << times[i] << "is in past, continuing";
          ++i;
        } //at this point we have either a matching time or nothing. Nothing would be bad...
        if(i < times.count()){ //there has been a matching time...
-         qDebug() << "[getNearestTime] Found future time at index" << i << ":" << times[i];
+         qDebug() << "Calendar::getNearestTime(): Found future time at index" << i << ":" << times[i];
          setWeeklyDate.setTime(times[i]);
        }
        if(i >= times.count()){ //there was no matching time, but there still might be one on another day.
-         qDebug() << "[getNearestTime] No more times today (i=" << i << "), checking next days...";
+         qDebug() << "Calendar::getNearestTime(): No more times today (i=" << i << "), checking next days...";
          if(calculatedDay.count() > 1){ //if there is at least another day...
-           qDebug() << "[getNearestTime]   Using next day (calculatedDay[1]=" << calculatedDay[1] << ")";
+           qDebug() << "Calendar::getNearestTime():   Using next day (calculatedDay[1]=" << calculatedDay[1] << ")";
            setWeeklyDate = QDateTime::currentDateTime().addDays(calculatedDay[1]); //take another day...
            times = getSortedTimes();      //and get the new times list.
            if(times.isEmpty()){
-             qDebug() << "[getNearestTime]   Times empty for next day, bailing";
+             qDebug() << "Calendar::getNearestTime():   Times empty for next day, bailing";
              setWeeklyDate = QDateTime();
              aDateWasSet();
              return;
            }
-           qDebug() << "[getNearestTime]   Using first time of next day:" << times[0];
+           qDebug() << "Calendar::getNearestTime():   Using first time of next day:" << times[0];
            setWeeklyDate.setTime(times[0]); //the first time setting will do.
          }
          else{ // there is no other day => +7
-           qDebug() << "[getNearestTime]   No more days this week, using same day next week +" << calculatedDay[0];
+           qDebug() << "Calendar::getNearestTime():   No more days this week, using same day next week +" << calculatedDay[0];
            setWeeklyDate = QDateTime::currentDateTime().addDays(7);
            setWeeklyDate.setTime(times[0]);
          }
        }
      }
-     qDebug() << "[getNearestTime] Final result: setWeeklyDate=" << setWeeklyDate;
+     qDebug() << "Calendar::getNearestTime(): Final result: setWeeklyDate=" << setWeeklyDate;
 }
 
 QList<QTime> Calendar::getSortedTimes(){
@@ -366,14 +366,14 @@ QList<QTime> Calendar::getSortedTimes(){
      else if(dow == Qt::Saturday){items = saturdayItems;  count = sat->spin->value(); dayName = "Saturday"; }
      else if(dow == Qt::Sunday){  items = sundayItems;    count = sun->spin->value(); dayName = "Sunday"; }
 
-     qDebug() << "[getSortedTimes] day=" << dayName << "dow=" << dow << "spin->value()=" << count << "items->size()=" << (items ? items->size() : 0);
+     qDebug() << "Calendar::getSortedTimes(): day=" << dayName << "dow=" << dow << "spin->value()=" << count << "items->size()=" << (items ? items->size() : 0);
 
      if(items){
        int n = qMin(count, items->size());
        for(int i = 0; i < n; ++i){
          QTime t = items->at(i)->timeEdit->time();
          times << t;
-         qDebug() << "[getSortedTimes]   added time[" << i << "]=" << t;
+         qDebug() << "Calendar::getSortedTimes():   added time[" << i << "]=" << t;
        }
      }
 
@@ -385,7 +385,7 @@ QList<QTime> Calendar::getSortedTimes(){
        }
      }
 
-     qDebug() << "[getSortedTimes] Final sorted times:" << times;
+     qDebug() << "Calendar::getSortedTimes(): Final sorted times:" << times;
      return times;
 }
 

--- a/qshutdown/src/calendar.h
+++ b/qshutdown/src/calendar.h
@@ -32,6 +32,7 @@ class Calendar : public QDialog, public Ui::Calendar {
      bool timeRunning;
      QDateTime setCalendarDate, calendarDate, setWeeklyDate;
      bool getClosed();
+     QList<QTime> getSortedTimes();
      WeekDay     *mon, *tue, *wed, *thu, *fri,
                  *sat, *sun;
      WeekDayItem *mon1, *mon2, *mon3, *mon4, *mon5,
@@ -59,7 +60,6 @@ class Calendar : public QDialog, public Ui::Calendar {
      void getDate(QDate date);
      void getSortedAndActivatedDays();
      void getNearestTime(QList<int> calculatedDay);
-     QList<QTime> getSortedTimes();
      void loadSettings();
      void saveToConfFile();
      void monday_addTimeEditAndActionBox(int i);

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -625,6 +625,8 @@ bool Gui::Time(){
 
      if(QDateTime::currentDateTimeUtc() > futureDateTime10s){ //if targeted time for action is
                           //already over 10 seconds in the past.
+       if(restartRecurringSleepCountdown())
+         return false;
        reset();
        return false;
      }
@@ -633,6 +635,28 @@ bool Gui::Time(){
        bigI = i; //for more precise display with LCD
        return true;
      }
+}
+
+bool Gui::restartRecurringSleepCountdown(){
+     if(!timeRunning || !aWeeklyTimeWasSet || !cal->weekly->isChecked())
+       return false;
+
+     if(!pref->restartRecurringSleepAfterResume)
+       return false;
+
+     // Only rearm if suspend or hibernate is selected (not shutdown/reboot)
+     if(!(suspend_action->isChecked() || hibernate_action->isChecked()))
+       return false;
+
+     timeRunning = false;
+     cal->timeRunning = false;
+     cal->setDate();
+
+     if(!cal->setWeeklyDate.isValid())
+       return false;
+
+     set();
+     return true;
 }
 
 void Gui::saveLog(){

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -639,53 +639,53 @@ bool Gui::Time(){
 }
 
 bool Gui::restartRecurringSleepCountdown(){
-     qDebug() << "[restartRecurringSleepCountdown] Checking restart conditions...";
+     qDebug() << "Gui::restartRecurringSleepCountdown(): Checking restart conditions...";
 
      if(!timeRunning || !aWeeklyTimeWasSet || !cal->weekly->isChecked()){
-       qDebug() << "[restartRecurringSleepCountdown] FAILED: timeRunning=" << timeRunning
+       qDebug() << "Gui::restartRecurringSleepCountdown(): Failed: timeRunning=" << timeRunning
                 << "aWeeklyTimeWasSet=" << aWeeklyTimeWasSet
                 << "weekly->isChecked()=" << cal->weekly->isChecked();
        return false;
      }
 
      if(!pref->restartRecurringSleepAfterResume){
-       qDebug() << "[restartRecurringSleepCountdown] FAILED: pref restartRecurringSleepAfterResume is false";
+       qDebug() << "Gui::restartRecurringSleepCountdown(): Failed: pref restartRecurringSleepAfterResume is false";
        return false;
      }
 
      // Only rearm if suspend or hibernate is selected (not shutdown/reboot)
      if(!(suspend_action->isChecked() || hibernate_action->isChecked())){
-       qDebug() << "[restartRecurringSleepCountdown] FAILED: action is not suspend/hibernate";
+       qDebug() << "Gui::restartRecurringSleepCountdown(): Failed: action is not suspend/hibernate";
        return false;
      }
 
-     qDebug() << "[restartRecurringSleepCountdown] All initial checks passed, calling cal->setDate()...";
+     qDebug() << "Gui::restartRecurringSleepCountdown(): All initial checks passed, calling cal->setDate()...";
      timeRunning = false;
      cal->timeRunning = false;
      cal->setDate();
 
-     qDebug() << "[restartRecurringSleepCountdown] After cal->setDate():"
+     qDebug() << "Gui::restartRecurringSleepCountdown(): After cal->setDate():"
               << "setWeeklyDate=" << cal->setWeeklyDate
               << "current time=" << QDateTime::currentDateTime()
               << "seconds to next=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
 
      if(!cal->setWeeklyDate.isValid()){
-       qDebug() << "[restartRecurringSleepCountdown] FAILED: setWeeklyDate is invalid";
+       qDebug() << "Gui::restartRecurringSleepCountdown(): Failed: setWeeklyDate is invalid";
        return false;
      }
 
      // Only suppress effectively-immediate retriggers after wake.
      const int graceSeconds = 10;
      int secsToNext = QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
-     qDebug() << "[restartRecurringSleepCountdown] Grace check: secsToNext=" << secsToNext
+     qDebug() << "Gui::restartRecurringSleepCountdown(): Grace check: secsToNext=" << secsToNext
               << "graceSeconds=" << graceSeconds
               << "check passes=" << (secsToNext > graceSeconds);
      if(secsToNext <= graceSeconds){
-       qDebug() << "[restartRecurringSleepCountdown] FAILED: grace period check";
+       qDebug() << "Gui::restartRecurringSleepCountdown(): Failed: grace period check";
        return false;
      }
 
-     qDebug() << "[restartRecurringSleepCountdown] SUCCESS: calling set() to restart countdown";
+     qDebug() << "Gui::restartRecurringSleepCountdown(): Success: calling set() to restart countdown";
      set();
      return true;
 }
@@ -772,7 +772,7 @@ void Gui::finished_(){
          && !pref->quitAfterCountdown->isChecked()
          && (suspend_action->isChecked() || hibernate_action->isChecked());
 
-     qDebug() << "[finished_] rearmRecurringSleep conditions:"
+     qDebug() << "Gui::finished_(): rearmRecurringSleep conditions:"
               << "restartRecurringSleepAfterResume=" << pref->restartRecurringSleepAfterResume
               << "aWeeklyTimeWasSet=" << aWeeklyTimeWasSet
               << "weekly->isChecked()=" << cal->weekly->isChecked()
@@ -782,12 +782,12 @@ void Gui::finished_(){
 
      bool didRearm = false;
      if(rearmRecurringSleep){
-       qDebug() << "[finished_] Attempting to rearm for next weekly occurrence...";
+       qDebug() << "Gui::finished_(): Attempting to rearm for next weekly occurrence...";
        // Recalculate the next weekly occurrence from "now" so it picks the
        // *next* time slot, not the one we're triggering this very moment.
        cal->setDate();
 
-       qDebug() << "[finished_] After cal->setDate():"
+       qDebug() << "Gui::finished_(): After cal->setDate():"
                 << "setWeeklyDate=" << cal->setWeeklyDate
                 << "current time=" << QDateTime::currentDateTime()
                 << "seconds to next=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
@@ -801,7 +801,7 @@ void Gui::finished_(){
        // the check would wrongly fail even though the next event is minutes away.
        QDateTime originalEventLocal = futureDateTime.toLocalTime();
        qint64 secsAfterOriginal = originalEventLocal.secsTo(cal->setWeeklyDate);
-       qDebug() << "[finished_] Grace check: originalEvent=" << originalEventLocal
+       qDebug() << "Gui::finished_(): Grace check: originalEvent=" << originalEventLocal
                 << "secsAfterOriginal=" << secsAfterOriginal;
 
        // If cal->setDate() returned the same event (secsAfterOriginal == 0),
@@ -823,15 +823,15 @@ void Gui::finished_(){
          if(nextTime.isValid()){
            cal->setWeeklyDate.setTime(nextTime);
            secsAfterOriginal = originalEventLocal.secsTo(cal->setWeeklyDate);
-           qDebug() << "[finished_] Same event returned, advanced to next time on same day:" << nextTime
+           qDebug() << "Gui::finished_(): Same event returned, advanced to next time on same day:" << nextTime
                     << "secsAfterOriginal=" << secsAfterOriginal;
          } else {
-           qDebug() << "[finished_] Same event returned, no later times found today";
+           qDebug() << "Gui::finished_(): Same event returned, no later times found today";
          }
        }
 
        if(cal->setWeeklyDate.isValid() && secsAfterOriginal > 0){
-         qDebug() << "[finished_] Grace check PASSED: next event is sufficiently in future";
+         qDebug() << "Gui::finished_(): Grace check passed: next event is sufficiently in future";
          // Retarget the still-running countdown in place (no reset()).
          // The timer keeps running; we just point futureDateTime to the next
          // occurrence so the user sees the new countdown immediately on wake.
@@ -868,9 +868,9 @@ void Gui::finished_(){
 
          updateT();    // refresh LCD with new countdown immediately
          didRearm = true;
-         qDebug() << "[finished_] Rearm SUCCESSFUL: futureDateTime set to" << futureDateTime;
+         qDebug() << "Gui::finished_(): Rearm successful: futureDateTime set to" << futureDateTime;
        } else {
-         qDebug() << "[finished_] Grace check FAILED: next event too close or invalid"
+         qDebug() << "Gui::finished_(): Grace check failed: next event too close or invalid"
                   << "isValid=" << cal->setWeeklyDate.isValid()
                   << "secsAfterOriginal=" << secsAfterOriginal
                   << "secsTo=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
@@ -878,10 +878,10 @@ void Gui::finished_(){
      }
 
      if(!didRearm && !pref->quitAfterCountdown->isChecked()){
-       qDebug() << "[finished_] Calling reset() (no rearm happened)";
+       qDebug() << "Gui::finished_(): Calling reset() (no rearm happened)";
        reset();
      } else if(didRearm) {
-       qDebug() << "[finished_] Skipping reset() because rearm was successful";
+       qDebug() << "Gui::finished_(): Skipping reset() because rearm was successful";
      }
 
      switch(currentActionIndex){
@@ -1022,7 +1022,7 @@ void Gui::finished_(){
      // and force a fresh display refresh. On Windows the QTimer's
      // underlying OS timer can be in a stale state after wake.
      if(didRearm){
-       qDebug() << "[finished_] Running post-resume safety net: timer stop/start";
+       qDebug() << "Gui::finished_(): Running post-resume safety net: timer stop/start";
        timer->stop();
        timer->start(1000);
        updateT();

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -792,13 +792,45 @@ void Gui::finished_(){
                 << "current time=" << QDateTime::currentDateTime()
                 << "seconds to next=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
 
-       // Safety check: only rearm if the next occurrence is genuinely in the
-       // future (not in the past, and not within a very tight window that
-       // suggests we're about to trigger it immediately again on wake).
-       // We use 1 second as the minimum to account for rounding and normal timer jitter.
-       const int minSecToNext = 1;
-       if(cal->setWeeklyDate.isValid()
-          && QDateTime::currentDateTime().secsTo(cal->setWeeklyDate) > minSecToNext){
+       // Safety check: only rearm if the next occurrence is strictly after the
+       // original event that just fired.  We compare against futureDateTime
+       // (the original deadline, in local time) rather than currentDateTime()
+       // because on Linux the 1-second QTimer tick can fire a few milliseconds
+       // before the integer-second boundary.  In that case currentDateTime() is
+       // still the same second as the firing event, secsTo() truncates to 0, and
+       // the check would wrongly fail even though the next event is minutes away.
+       QDateTime originalEventLocal = futureDateTime.toLocalTime();
+       qint64 secsAfterOriginal = originalEventLocal.secsTo(cal->setWeeklyDate);
+       qDebug() << "[finished_] Grace check: originalEvent=" << originalEventLocal
+                << "secsAfterOriginal=" << secsAfterOriginal;
+
+       // If cal->setDate() returned the same event (secsAfterOriginal == 0),
+       // it means the current time is still slightly before the event time.
+       // This can happen after suspend/resume if the user resumes very quickly.
+       // In this case, try to find the next time slot on the same day.
+       if(cal->setWeeklyDate.isValid() && secsAfterOriginal == 0){
+         QList<QTime> times = cal->getSortedTimes();
+         QTime originalTime = originalEventLocal.time();
+         QTime nextTime = QTime();
+
+         for(const QTime &t : times){
+           if(t > originalTime){
+             nextTime = t;
+             break;
+           }
+         }
+
+         if(nextTime.isValid()){
+           cal->setWeeklyDate.setTime(nextTime);
+           secsAfterOriginal = originalEventLocal.secsTo(cal->setWeeklyDate);
+           qDebug() << "[finished_] Same event returned, advanced to next time on same day:" << nextTime
+                    << "secsAfterOriginal=" << secsAfterOriginal;
+         } else {
+           qDebug() << "[finished_] Same event returned, no later times found today";
+         }
+       }
+
+       if(cal->setWeeklyDate.isValid() && secsAfterOriginal > 0){
          qDebug() << "[finished_] Grace check PASSED: next event is sufficiently in future";
          // Retarget the still-running countdown in place (no reset()).
          // The timer keeps running; we just point futureDateTime to the next
@@ -840,6 +872,7 @@ void Gui::finished_(){
        } else {
          qDebug() << "[finished_] Grace check FAILED: next event too close or invalid"
                   << "isValid=" << cal->setWeeklyDate.isValid()
+                  << "secsAfterOriginal=" << secsAfterOriginal
                   << "secsTo=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
        }
      }

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -655,6 +655,13 @@ bool Gui::restartRecurringSleepCountdown(){
      if(!cal->setWeeklyDate.isValid())
        return false;
 
+     // Grace period: if the next scheduled time is too close (<= 180s),
+     // skip it to prevent a suspend loop after wake-up where the OS hasn't
+     // finished logging back in before the next countdown expires.
+     const int graceSeconds = 180;
+     if(QDateTime::currentDateTime().secsTo(cal->setWeeklyDate) <= graceSeconds)
+       return false;
+
      set();
      return true;
 }
@@ -726,10 +733,29 @@ void Gui::saveLast(){
 
 void Gui::finished_(){
      saveLast();
-     if(!pref->quitAfterCountdown->isChecked())
+
+     // Capture the action to be performed NOW, in case any later code
+     // ends up mutating comboBox to reflect the next recurrence's action.
+     int currentActionIndex = comboBox->currentIndex();
+
+     // Detect: should we rearm a recurring weekly countdown for the next
+     // occurrence after Power::suspend() / Power::hibernate() returns
+     // post-resume? Otherwise the countdown is dead after wake-up.
+     bool rearmRecurringSleep =
+         pref->restartRecurringSleepAfterResume
+         && aWeeklyTimeWasSet
+         && cal->weekly->isChecked()
+         && !pref->quitAfterCountdown->isChecked()
+         && (suspend_action->isChecked() || hibernate_action->isChecked());
+
+     // If we are NOT rearming, behave like before: reset the UI/timer now.
+     // If we ARE rearming, intentionally skip reset() so timeRunning/state stays
+     // intact across the suspend/hibernate call and the post-wake rearm can
+     // simply retarget futureDateTime in place.
+     if(!rearmRecurringSleep && !pref->quitAfterCountdown->isChecked())
        reset();
 
-     switch(comboBox->currentIndex()){
+     switch(currentActionIndex){
        case 0: //shutdown
          switch(pref->shutdownM->currentIndex()){ //shutdown method settings
             case 0:
@@ -860,6 +886,64 @@ void Gui::finished_(){
 
        default:;
      }
+
+     // Post-resume rearm: this code only executes after Power::suspend() /
+     // Power::hibernate() has returned (i.e. the system has woken up again).
+     // For shutdown/reboot, this code is unreachable because the OS kills us
+     // before the call returns.
+     if(rearmRecurringSleep){
+       cal->setDate();   // recalculate next weekly occurrence from "now"
+
+       // Grace period: skip rearm if next occurrence is within 180s, to
+       // prevent a suspend loop on wake-up when the user has multiple times
+       // scheduled close together (e.g. 23:11 and 23:13 on the same day).
+       const int graceSeconds = 180;
+       if(cal->setWeeklyDate.isValid()
+          && QDateTime::currentDateTime().secsTo(cal->setWeeklyDate) > graceSeconds){
+         // Retarget the countdown in place: keep timeRunning state, just
+         // point futureDateTime to the next occurrence and refresh the LCD.
+         futureDateTime = cal->setWeeklyDate.toUTC();
+         TIcon->setIcon(QPixmap(":running"));
+
+         // Propagate next occurrence's per-item action to the main comboBox
+         // so the next trigger uses the correct power action.
+         QList<WeekDayItem *> items;
+         int dow = cal->setWeeklyDate.date().dayOfWeek();
+         if(dow == Qt::Monday)
+           items << cal->mon1 << cal->mon2 << cal->mon3 << cal->mon4 << cal->mon5;
+         else if(dow == Qt::Tuesday)
+           items << cal->tue1 << cal->tue2 << cal->tue3 << cal->tue4 << cal->tue5;
+         else if(dow == Qt::Wednesday)
+           items << cal->wed1 << cal->wed2 << cal->wed3 << cal->wed4 << cal->wed5;
+         else if(dow == Qt::Thursday)
+           items << cal->thu1 << cal->thu2 << cal->thu3 << cal->thu4 << cal->thu5;
+         else if(dow == Qt::Friday)
+           items << cal->fri1 << cal->fri2 << cal->fri3 << cal->fri4 << cal->fri5;
+         else if(dow == Qt::Saturday)
+           items << cal->sat1 << cal->sat2 << cal->sat3 << cal->sat4 << cal->sat5;
+         else if(dow == Qt::Sunday)
+           items << cal->sun1 << cal->sun2 << cal->sun3 << cal->sun4 << cal->sun5;
+         QTime nextTime = cal->setWeeklyDate.time();
+         foreach(WeekDayItem *it, items){
+           if(it->timeEdit->time() == nextTime){
+             comboBox->setCurrentIndex(it->comboBox->currentIndex());
+             break;
+           }
+         }
+
+         // Force a fresh OS-level QTimer (after suspend its underlying timer
+         // can be in a stale state on Windows). stop()+start() guarantees a
+         // clean re-arm.
+         timer->stop();
+         timer->start(1000);
+         updateT();   // refresh LCD with new countdown immediately
+       }
+       else{
+         // No valid next occurrence (or within grace) -> behave as before.
+         reset();
+       }
+     }
+
      if(pref->quitAfterCountdown->isChecked())
        qApp->quit();
 }

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -26,6 +26,7 @@
 #include <QTimer>
 #include <QStandardPaths>
 #include <QActionGroup>
+#include <QDebug>
 
 Gui::Gui(){
 
@@ -638,30 +639,53 @@ bool Gui::Time(){
 }
 
 bool Gui::restartRecurringSleepCountdown(){
-     if(!timeRunning || !aWeeklyTimeWasSet || !cal->weekly->isChecked())
-       return false;
+     qDebug() << "[restartRecurringSleepCountdown] Checking restart conditions...";
 
-     if(!pref->restartRecurringSleepAfterResume)
+     if(!timeRunning || !aWeeklyTimeWasSet || !cal->weekly->isChecked()){
+       qDebug() << "[restartRecurringSleepCountdown] FAILED: timeRunning=" << timeRunning
+                << "aWeeklyTimeWasSet=" << aWeeklyTimeWasSet
+                << "weekly->isChecked()=" << cal->weekly->isChecked();
        return false;
+     }
+
+     if(!pref->restartRecurringSleepAfterResume){
+       qDebug() << "[restartRecurringSleepCountdown] FAILED: pref restartRecurringSleepAfterResume is false";
+       return false;
+     }
 
      // Only rearm if suspend or hibernate is selected (not shutdown/reboot)
-     if(!(suspend_action->isChecked() || hibernate_action->isChecked()))
+     if(!(suspend_action->isChecked() || hibernate_action->isChecked())){
+       qDebug() << "[restartRecurringSleepCountdown] FAILED: action is not suspend/hibernate";
        return false;
+     }
 
+     qDebug() << "[restartRecurringSleepCountdown] All initial checks passed, calling cal->setDate()...";
      timeRunning = false;
      cal->timeRunning = false;
      cal->setDate();
 
-     if(!cal->setWeeklyDate.isValid())
-       return false;
+     qDebug() << "[restartRecurringSleepCountdown] After cal->setDate():"
+              << "setWeeklyDate=" << cal->setWeeklyDate
+              << "current time=" << QDateTime::currentDateTime()
+              << "seconds to next=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
 
-     // Grace period: if the next scheduled time is too close (<= 180s),
-     // skip it to prevent a suspend loop after wake-up where the OS hasn't
-     // finished logging back in before the next countdown expires.
-     const int graceSeconds = 180;
-     if(QDateTime::currentDateTime().secsTo(cal->setWeeklyDate) <= graceSeconds)
+     if(!cal->setWeeklyDate.isValid()){
+       qDebug() << "[restartRecurringSleepCountdown] FAILED: setWeeklyDate is invalid";
        return false;
+     }
 
+     // Only suppress effectively-immediate retriggers after wake.
+     const int graceSeconds = 10;
+     int secsToNext = QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
+     qDebug() << "[restartRecurringSleepCountdown] Grace check: secsToNext=" << secsToNext
+              << "graceSeconds=" << graceSeconds
+              << "check passes=" << (secsToNext > graceSeconds);
+     if(secsToNext <= graceSeconds){
+       qDebug() << "[restartRecurringSleepCountdown] FAILED: grace period check";
+       return false;
+     }
+
+     qDebug() << "[restartRecurringSleepCountdown] SUCCESS: calling set() to restart countdown";
      set();
      return true;
 }
@@ -734,13 +758,13 @@ void Gui::saveLast(){
 void Gui::finished_(){
      saveLast();
 
-     // Capture the action to be performed NOW, in case any later code
-     // ends up mutating comboBox to reflect the next recurrence's action.
+     // Capture the action to be performed NOW, before the rearm path may
+     // mutate comboBox to reflect the next occurrence's action.
      int currentActionIndex = comboBox->currentIndex();
 
      // Detect: should we rearm a recurring weekly countdown for the next
-     // occurrence after Power::suspend() / Power::hibernate() returns
-     // post-resume? Otherwise the countdown is dead after wake-up.
+     // occurrence? Without rearming, the countdown is dead after wake-up
+     // because reset() would have stopped the timer.
      bool rearmRecurringSleep =
          pref->restartRecurringSleepAfterResume
          && aWeeklyTimeWasSet
@@ -748,12 +772,84 @@ void Gui::finished_(){
          && !pref->quitAfterCountdown->isChecked()
          && (suspend_action->isChecked() || hibernate_action->isChecked());
 
-     // If we are NOT rearming, behave like before: reset the UI/timer now.
-     // If we ARE rearming, intentionally skip reset() so timeRunning/state stays
-     // intact across the suspend/hibernate call and the post-wake rearm can
-     // simply retarget futureDateTime in place.
-     if(!rearmRecurringSleep && !pref->quitAfterCountdown->isChecked())
+     qDebug() << "[finished_] rearmRecurringSleep conditions:"
+              << "restartRecurringSleepAfterResume=" << pref->restartRecurringSleepAfterResume
+              << "aWeeklyTimeWasSet=" << aWeeklyTimeWasSet
+              << "weekly->isChecked()=" << cal->weekly->isChecked()
+              << "quitAfterCountdown=" << pref->quitAfterCountdown->isChecked()
+              << "suspend/hibernate=" << (suspend_action->isChecked() || hibernate_action->isChecked())
+              << "=> rearmRecurringSleep=" << rearmRecurringSleep;
+
+     bool didRearm = false;
+     if(rearmRecurringSleep){
+       qDebug() << "[finished_] Attempting to rearm for next weekly occurrence...";
+       // Recalculate the next weekly occurrence from "now" so it picks the
+       // *next* time slot, not the one we're triggering this very moment.
+       cal->setDate();
+
+       qDebug() << "[finished_] After cal->setDate():"
+                << "setWeeklyDate=" << cal->setWeeklyDate
+                << "current time=" << QDateTime::currentDateTime()
+                << "seconds to next=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
+
+       // Safety check: only rearm if the next occurrence is genuinely in the
+       // future (not in the past, and not within a very tight window that
+       // suggests we're about to trigger it immediately again on wake).
+       // We use 1 second as the minimum to account for rounding and normal timer jitter.
+       const int minSecToNext = 1;
+       if(cal->setWeeklyDate.isValid()
+          && QDateTime::currentDateTime().secsTo(cal->setWeeklyDate) > minSecToNext){
+         qDebug() << "[finished_] Grace check PASSED: next event is sufficiently in future";
+         // Retarget the still-running countdown in place (no reset()).
+         // The timer keeps running; we just point futureDateTime to the next
+         // occurrence so the user sees the new countdown immediately on wake.
+         futureDateTime = cal->setWeeklyDate.toUTC();
+         TIcon->setIcon(QPixmap(":running"));
+
+         // Propagate next occurrence's per-item action to the main comboBox
+         // (Gui::setDate() skips this while timeRunning==true, so do it here).
+         {
+           QList<WeekDayItem *> items;
+           int dow = cal->setWeeklyDate.date().dayOfWeek();
+           if(dow == Qt::Monday)
+             items << cal->mon1 << cal->mon2 << cal->mon3 << cal->mon4 << cal->mon5;
+           else if(dow == Qt::Tuesday)
+             items << cal->tue1 << cal->tue2 << cal->tue3 << cal->tue4 << cal->tue5;
+           else if(dow == Qt::Wednesday)
+             items << cal->wed1 << cal->wed2 << cal->wed3 << cal->wed4 << cal->wed5;
+           else if(dow == Qt::Thursday)
+             items << cal->thu1 << cal->thu2 << cal->thu3 << cal->thu4 << cal->thu5;
+           else if(dow == Qt::Friday)
+             items << cal->fri1 << cal->fri2 << cal->fri3 << cal->fri4 << cal->fri5;
+           else if(dow == Qt::Saturday)
+             items << cal->sat1 << cal->sat2 << cal->sat3 << cal->sat4 << cal->sat5;
+           else if(dow == Qt::Sunday)
+             items << cal->sun1 << cal->sun2 << cal->sun3 << cal->sun4 << cal->sun5;
+           QTime nextTime = cal->setWeeklyDate.time();
+           foreach(WeekDayItem *it, items){
+             if(it->timeEdit->time() == nextTime){
+               comboBox->setCurrentIndex(it->comboBox->currentIndex());
+               break;
+             }
+           }
+         }
+
+         updateT();    // refresh LCD with new countdown immediately
+         didRearm = true;
+         qDebug() << "[finished_] Rearm SUCCESSFUL: futureDateTime set to" << futureDateTime;
+       } else {
+         qDebug() << "[finished_] Grace check FAILED: next event too close or invalid"
+                  << "isValid=" << cal->setWeeklyDate.isValid()
+                  << "secsTo=" << QDateTime::currentDateTime().secsTo(cal->setWeeklyDate);
+       }
+     }
+
+     if(!didRearm && !pref->quitAfterCountdown->isChecked()){
+       qDebug() << "[finished_] Calling reset() (no rearm happened)";
        reset();
+     } else if(didRearm) {
+       qDebug() << "[finished_] Skipping reset() because rearm was successful";
+     }
 
      switch(currentActionIndex){
        case 0: //shutdown
@@ -887,61 +983,16 @@ void Gui::finished_(){
        default:;
      }
 
-     // Post-resume rearm: this code only executes after Power::suspend() /
-     // Power::hibernate() has returned (i.e. the system has woken up again).
-     // For shutdown/reboot, this code is unreachable because the OS kills us
-     // before the call returns.
-     if(rearmRecurringSleep){
-       cal->setDate();   // recalculate next weekly occurrence from "now"
-
-       // Grace period: skip rearm if next occurrence is within 180s, to
-       // prevent a suspend loop on wake-up when the user has multiple times
-       // scheduled close together (e.g. 23:11 and 23:13 on the same day).
-       const int graceSeconds = 180;
-       if(cal->setWeeklyDate.isValid()
-          && QDateTime::currentDateTime().secsTo(cal->setWeeklyDate) > graceSeconds){
-         // Retarget the countdown in place: keep timeRunning state, just
-         // point futureDateTime to the next occurrence and refresh the LCD.
-         futureDateTime = cal->setWeeklyDate.toUTC();
-         TIcon->setIcon(QPixmap(":running"));
-
-         // Propagate next occurrence's per-item action to the main comboBox
-         // so the next trigger uses the correct power action.
-         QList<WeekDayItem *> items;
-         int dow = cal->setWeeklyDate.date().dayOfWeek();
-         if(dow == Qt::Monday)
-           items << cal->mon1 << cal->mon2 << cal->mon3 << cal->mon4 << cal->mon5;
-         else if(dow == Qt::Tuesday)
-           items << cal->tue1 << cal->tue2 << cal->tue3 << cal->tue4 << cal->tue5;
-         else if(dow == Qt::Wednesday)
-           items << cal->wed1 << cal->wed2 << cal->wed3 << cal->wed4 << cal->wed5;
-         else if(dow == Qt::Thursday)
-           items << cal->thu1 << cal->thu2 << cal->thu3 << cal->thu4 << cal->thu5;
-         else if(dow == Qt::Friday)
-           items << cal->fri1 << cal->fri2 << cal->fri3 << cal->fri4 << cal->fri5;
-         else if(dow == Qt::Saturday)
-           items << cal->sat1 << cal->sat2 << cal->sat3 << cal->sat4 << cal->sat5;
-         else if(dow == Qt::Sunday)
-           items << cal->sun1 << cal->sun2 << cal->sun3 << cal->sun4 << cal->sun5;
-         QTime nextTime = cal->setWeeklyDate.time();
-         foreach(WeekDayItem *it, items){
-           if(it->timeEdit->time() == nextTime){
-             comboBox->setCurrentIndex(it->comboBox->currentIndex());
-             break;
-           }
-         }
-
-         // Force a fresh OS-level QTimer (after suspend its underlying timer
-         // can be in a stale state on Windows). stop()+start() guarantees a
-         // clean re-arm.
-         timer->stop();
-         timer->start(1000);
-         updateT();   // refresh LCD with new countdown immediately
-       }
-       else{
-         // No valid next occurrence (or within grace) -> behave as before.
-         reset();
-       }
+     // Post-resume safety net: after Power::suspend() / Power::hibernate()
+     // returns (i.e. the system has woken up again), if we rearmed for a
+     // future recurring occurrence, make sure the QTimer is still alive
+     // and force a fresh display refresh. On Windows the QTimer's
+     // underlying OS timer can be in a stale state after wake.
+     if(didRearm){
+       qDebug() << "[finished_] Running post-resume safety net: timer stop/start";
+       timer->stop();
+       timer->start(1000);
+       updateT();
      }
 
      if(pref->quitAfterCountdown->isChecked())

--- a/qshutdown/src/gui.h
+++ b/qshutdown/src/gui.h
@@ -101,6 +101,7 @@ class Gui : public QMainWindow, public Ui::Gui {
      void saveOldTime(QTime time);
      void saveOldComboBoxIndex(int i);
      void setDate();
+    bool restartRecurringSleepCountdown();
      void lockEverything(bool actual);
      void updateLock();
      void showEditor();

--- a/qshutdown/src/pixmap/red_glasses.svg
+++ b/qshutdown/src/pixmap/red_glasses.svg
@@ -1,0 +1,67 @@
+<svg viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <radialGradient id="faceGradient" cx="38%" cy="35%" r="72%">
+      <stop offset="0%" style="stop-color:#fff4a8" />
+      <stop offset="40%" style="stop-color:#f5d860" />
+      <stop offset="80%" style="stop-color:#d4a82c" />
+      <stop offset="100%" style="stop-color:#9a7820" />
+    </radialGradient>
+    <linearGradient id="lensGradient" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#c81818" />
+      <stop offset="55%" style="stop-color:#840606" />
+      <stop offset="100%" style="stop-color:#3e0101" />
+    </linearGradient>
+    <radialGradient id="faceHighlight" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:1" />
+      <stop offset="35%" style="stop-color:#ffffff;stop-opacity:0.55" />
+      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0" />
+    </radialGradient>
+    <linearGradient id="lensShine" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#ffffff;stop-opacity:0.4" />
+      <stop offset="50%" style="stop-color:#ffffff;stop-opacity:0.05" />
+      <stop offset="100%" style="stop-color:#ffffff;stop-opacity:0" />
+    </linearGradient>
+  </defs>
+
+  <!-- Face -->
+  <circle cx="100" cy="100" r="95" fill="url(#faceGradient)"/>
+  <ellipse cx="60" cy="52" rx="42" ry="30" fill="url(#faceHighlight)"/>
+
+  <!-- Bridge (small) -->
+  <path d="M 95 80 Q 100 84 105 80" stroke="#0a0a0a" stroke-width="3.5" fill="none" stroke-linecap="round"/>
+
+  <!-- Left lens: shorter -->
+  <path d="M 18 68
+           L 86 68
+           Q 92 68 92 73
+           L 92 90
+           Q 88 102 55 104
+           Q 18 102 13 90
+           L 13 73
+           Q 13 68 18 68 Z"
+        fill="url(#lensGradient)" stroke="#0a0a0a" stroke-width="2.5" stroke-linejoin="round"/>
+  <path d="M 20 71 L 88 71 L 90 76 Q 55 86 14 76 L 14 73 Q 14 71 20 71 Z" fill="url(#lensShine)"/>
+  <ellipse cx="40" cy="76" rx="16" ry="3.5" fill="#ffffff" opacity="0.5"/>
+
+  <!-- Right lens: mirrored -->
+  <path d="M 114 68
+           L 182 68
+           Q 187 68 187 73
+           L 187 90
+           Q 182 102 145 104
+           Q 108 102 108 90
+           L 108 73
+           Q 108 68 114 68 Z"
+        fill="url(#lensGradient)" stroke="#0a0a0a" stroke-width="2.5" stroke-linejoin="round"/>
+  <path d="M 110 71 L 180 71 L 186 71 L 186 76 Q 145 86 110 76 L 110 71 Z" fill="url(#lensShine)"/>
+  <ellipse cx="138" cy="76" rx="16" ry="3.5" fill="#ffffff" opacity="0.45"/>
+
+  <!-- Temple arms (drawn on top of lenses): short stubs from outer-top lens corner going back -->
+  <path d="M 14 71 Q 9 76 11 88" stroke="#0a0a0a" stroke-width="3" fill="none" stroke-linecap="round"/>
+  <path d="M 186 71 Q 191 76 189 88" stroke="#0a0a0a" stroke-width="3" fill="none" stroke-linecap="round"/>
+
+  <!-- Mouth: flat middle (wider), both corners lift UP -->
+  <path d="M 46 136 Q 52 142 60 142 L 140 142 Q 148 142 154 136"
+        stroke="#5a3a08" stroke-width="3.8" fill="none"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/qshutdown/src/preferences.cpp
+++ b/qshutdown/src/preferences.cpp
@@ -213,6 +213,7 @@ void Preferences::loadSettings(){
      quitOnCloseMain->setChecked(settings->value("Quit_on_close",true).toBool());
      rememberOnClose->setChecked(settings->value("MainWindow/remember_last", false).toBool());
      countdown->setChecked(settings->value("Time/countdown_at_startup",false).toBool());
+    restartSleepCountdown->setChecked(settings->value("Time/restart_recurring_sleep_countdown_after_resume",false).toBool());
      hideMe->setChecked(settings->value("Hide_at_startup",false).toBool());
      fontComboBox->setCurrentFont(settings->value("Fonts/font_type",fonts).toString());
      font1Spin->setValue(settings->value("Fonts/font1",fontS1).toInt());
@@ -238,6 +239,7 @@ void Preferences::loadSettings(){
      userDef4->setPlainText(settings->value("Methods/myHibernate",userDef4S).toString());
      lockMyScreen = settings->value("Lock_screen").toBool();
      quitAfterCountdown->setChecked(settings->value("Quit_after_countdown_ended",false).toBool());
+    restartRecurringSleepAfterResume = restartSleepCountdown->isChecked();
      
      showNotRunning = remindCndPop->isChecked();
      showEndOfCountdown = warn->isChecked();
@@ -251,6 +253,7 @@ void Preferences::saveToConfFile(){
        settings->setValue("Quit_on_close",quitOnCloseMain->isChecked());
        settings->setValue("MainWindow/remember_last",rememberOnClose->isChecked());
        settings->setValue("Time/countdown_at_startup",countdown->isChecked());
+      settings->setValue("Time/restart_recurring_sleep_countdown_after_resume",restartSleepCountdown->isChecked());
        settings->setValue("Hide_at_startup",hideMe->isChecked());
        settings->setValue("Time/countdown_minutes",spin->value());
        settings->setValue("Fonts/font_type",fontComboBox->currentText());
@@ -279,6 +282,7 @@ void Preferences::saveToConfFile(){
      }
      autostartFile(); //to create or to delete the autostart file
      lockScreen();    //set lockMyScreen to true or false according to lockS
+     restartRecurringSleepAfterResume = restartSleepCountdown->isChecked();
 
      if(userDef1->isEnabled())
        myShutdown = userDef1->toPlainText();
@@ -308,6 +312,7 @@ void Preferences::resetSettings(){
        quitOnCloseMain->setChecked(true);
        rememberOnClose->setChecked(false);
        hideMe->setChecked(false);
+      restartSleepCountdown->setChecked(false);
        spin->setValue(60);
        fontComboBox->setCurrentFont(QFont(fonts));
        font1Spin->setValue(fontS1);

--- a/qshutdown/src/preferences.h
+++ b/qshutdown/src/preferences.h
@@ -33,6 +33,7 @@ class Preferences : public QDialog, public Ui::Preferences {
      int fontS1, fontS2, fontS3;
      bool getClosed();
      bool lockMyScreen;
+     bool restartRecurringSleepAfterResume;
      bool showNotRunning;
      bool showEndOfCountdown;
 

--- a/qshutdown/src/ui/gui.ui
+++ b/qshutdown/src/ui/gui.ui
@@ -85,6 +85,9 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="minimumWidth">
+             <number>110</number>
+            </property>
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>1</horstretch>

--- a/qshutdown/src/ui/preferences.ui
+++ b/qshutdown/src/ui/preferences.ui
@@ -427,6 +427,16 @@ should be checked by default at startup</string>
               </widget>
              </item>
              <item>
+              <widget class="QCheckBox" name="restartSleepCountdown">
+               <property name="toolTip">
+                <string>After a recurring suspend or hibernate, qshutdown may still be running when the computer wakes up. Restart the recurring countdown automatically in that case.</string>
+               </property>
+               <property name="text">
+                <string>Restart recurring suspend/hibernate countdown after wake-up</string>
+               </property>
+              </widget>
+             </item>
+             <item>
               <widget class="QCheckBox" name="hideMe">
                <property name="enabled">
                 <bool>false</bool>

--- a/qshutdown/src/weekdayitem.cpp
+++ b/qshutdown/src/weekdayitem.cpp
@@ -17,6 +17,7 @@
 
 #include "weekdayitem.h"
 #include <QCoreApplication>
+#include <QSettings>
 
 WeekDayItem::WeekDayItem(QWidget *parent) : QWidget(parent){
      itemL = new QHBoxLayout(this);
@@ -39,6 +40,15 @@ WeekDayItem::WeekDayItem(QWidget *parent) : QWidget(parent){
          << QCoreApplication::translate("Gui", "Suspend", 0)
          << QCoreApplication::translate("Gui", "Hibernate", 0)
         );
+     // Initialise to the user's default action from preferences
+     // ("Power/comboBox"), so freshly-opened weekday rows match what the
+     // user picked as the default shutdown type, rather than always Shutdown.
+     {
+       QSettings s;
+       int def = s.value("Power/comboBox", 0).toInt();
+       if(def < 0 || def > 3) def = 0;
+       comboBox->setCurrentIndex(def);
+     }
 
      itemL->addItem(h2);
      itemL->addWidget(timeEdit);


### PR DESCRIPTION
Added a new setting to resume the qshutdown countdown after waking up the computer, when there are multiple suspends scheduled in the weekly settings. 

This also contains additional code to increase the "resilience" in case of things going wrong shortly after resuming from suspend. 

1.) After standby QDateTime sometimes returns a wrong time, i.e. a time in the past or the time when the suspend call happened. 
2.) Avoiding triggering twice on the same suspend event, else this causes a sort of "boot-suspend-loop" that can only be exited by physically shutting down the PC. 
3.) (precaution) re-starting QTimers that might stop firing after a suspend/hibernate