### PR TITLE
Fix reset with weekly

### DIFF
--- a/qshutdown/src/calendar.cpp
+++ b/qshutdown/src/calendar.cpp
@@ -198,6 +198,10 @@ Calendar::Calendar(QWidget *parent): QDialog(parent){
      connect(sun->spin, SIGNAL(valueChanged(int)), this, SLOT(sunday_addTimeEditAndActionBox(int)));
 
      loadSettings();
+     if(settings->value("MainWindow/remember_last",false).toBool()){
+       weekly->setChecked(settings->value("LastSetting/weekly", false).toBool());
+     }
+     oldWeekly = weekly->isChecked();
 
 }
 
@@ -206,6 +210,7 @@ Calendar::~Calendar(){ delete settings; }
 void Calendar::getDate(QDate date){ calendarDate.setDate(date); }
 
 void Calendar::setDate(){
+     oldWeekly = weekly->isChecked();
        qDebug() << "Calendar::setDate(): Called at" << QDateTime::currentDateTime();
      if(calendarWidget->selectedDate() != QDate::currentDate())
         calendarDate.setDate(calendarWidget->selectedDate());
@@ -380,6 +385,7 @@ QList<QTime> Calendar::getSortedTimes(){
 
 void Calendar::showEvent(QShowEvent* show_calendar){
      isClosed = false;
+     weekly->setChecked(oldWeekly); //recover previously used weekly setting
      starting();
      loadSettings();
      QDialog::showEvent(show_calendar);

--- a/qshutdown/src/calendar.h
+++ b/qshutdown/src/calendar.h
@@ -30,6 +30,7 @@ class Calendar : public QDialog, public Ui::Calendar {
      Calendar(QWidget *parent = 0);
      ~Calendar();
      bool timeRunning;
+     bool oldWeekly;
      QDateTime setCalendarDate, calendarDate, setWeeklyDate;
      bool getClosed();
      QList<QTime> getSortedTimes();

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -258,7 +258,7 @@ void Gui::saveOldComboBoxIndex(int i){
 }
 
 void Gui::setDate(){
-     if(timeRunning) return;
+     //if(timeRunning) return;
      if(!cal->weekly->isChecked()) {
        if(cal->setCalendarDate.date() != QDate())
          toolButton->setText(QLocale::system().toString(cal->setCalendarDate.date(),QLocale::ShortFormat));
@@ -295,8 +295,8 @@ void Gui::setDate(){
        timeEdit->setDisabled(true);
        comboBox->setDisabled(true);
      }
-     if((cal->setCalendarDate == QDateTime()) && (cal->setWeeklyDate == QDateTime()))
-       if(!timeRunning){
+     if(cal->setCalendarDate == QDateTime() && 
+       cal->setWeeklyDate == QDateTime() && !cal->weekly->isChecked()){
           timeEdit->setTime(oldTime);
           comboBox->setCurrentIndex(oldComboBoxIndex);
           aWeeklyTimeWasSet = false;
@@ -308,7 +308,7 @@ void Gui::setDate(){
             spin->setDisabled(false);
           comboBox->setDisabled(false);
           toolButton->setText(tr("Calendar"));
-       }
+     }
 }
 
 void Gui::center(){

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -258,11 +258,12 @@ void Gui::saveOldComboBoxIndex(int i){
 }
 
 void Gui::setDate(){
-     if(!cal->weekly->isChecked() && !timeRunning) {
+     if(timeRunning) return;
+     if(!cal->weekly->isChecked()) {
        if(cal->setCalendarDate.date() != QDate())
          toolButton->setText(QLocale::system().toString(cal->setCalendarDate.date(),QLocale::ShortFormat));
      }
-     else if(!cal->setWeeklyDate.time().isNull() && !timeRunning){
+     else if(!cal->setWeeklyDate.time().isNull()){
        toolButton->setText(cal->setWeeklyDate.date().toString("ddd"));
        aWeeklyTimeWasSet = true;
        timeEdit->setTime(cal->setWeeklyDate.time());
@@ -569,6 +570,14 @@ void Gui::updateT(){
 }
 
 void Gui::set(){
+     if(!lock->isChecked() && timeRunning){
+      QDate tdate = cal->calendarDate.date();
+      reset();
+      if(cal->weekly->isChecked() || tdate.isValid()){
+        cal->calendarDate.setDate(tdate);
+        cal->setDate();
+      }
+     }
      TIcon->setIcon(QPixmap(":running"));
      QDateTime localDT = QDateTime::currentDateTime();
      QDateTime localFutureDateTime = localDT; //initializing
@@ -1066,7 +1075,7 @@ void Gui::lockEverything(bool actual){
        action_Reset->setDisabled(true);
      }
      
-     if(cal->weekly->isChecked() && aWeeklyTimeWasSet){
+     if(cal->weekly->isChecked()){
        radio1->setChecked(true);
        radio2->setDisabled(true);
        radio1->setDisabled(true);

--- a/qshutdown/src/gui.cpp
+++ b/qshutdown/src/gui.cpp
@@ -602,7 +602,8 @@ void Gui::set(){
      if(lock->isChecked() || editor->getLockAll()){       //when OK-button is clicked and lock is checked
        QList<QWidget*> list;
        list << spin << radio1 << radio2 << lock << timeEdit << comboBox << targetTime
-            << minutes << pref->tab2 << cal->weekly << cal->scrollAreaWidgetContents;
+            << minutes << pref->tab2 << cal->weekly << cal->scrollAreaWidgetContents
+            << cal->calendarWidget;
        foreach(QWidget * ptr, list)
          ptr->setDisabled(true);
        power_actions->setDisabled(true);
@@ -658,7 +659,6 @@ bool Gui::restartRecurringSleepCountdown()
             timeRunning = false;
             cal->timeRunning = false;
             cal->setDate();
-            setDate();
             set();
             elapsedTime.restart();
             return true;
@@ -1020,7 +1020,6 @@ void Gui::loadSettings(){
      }
      
      cal->setDate();
-     setDate();
 
      if (settings.value("Time/countdown_at_startup", false).toBool()) {
          set();
@@ -1046,7 +1045,8 @@ void Gui::lockEverything(bool actual){
                 << minutes << pref->comboBox << pref->timeEdit << pref->spin
                 << pref->radio1 << pref->radio2 << pref->quitOnCloseMain
                 << pref->autostart << pref->lock << pref->countdown
-                << pref->log << pref->reset << pref->spinBox << pref->tab2;
+                << pref->log << pref->reset << pref->spinBox << pref->tab2
+                << cal->weekly << cal->scrollAreaWidgetContents << cal->calendarWidget;
      foreach(QWidget * widgetPtr, widgetList)
        widgetPtr->setDisabled(actual);
 
@@ -1066,7 +1066,7 @@ void Gui::lockEverything(bool actual){
        action_Reset->setDisabled(true);
      }
      
-     if(aWeeklyTimeWasSet){
+     if(cal->weekly->isChecked() && aWeeklyTimeWasSet){
        radio1->setChecked(true);
        radio2->setDisabled(true);
        radio1->setDisabled(true);
@@ -1092,10 +1092,8 @@ void Gui::reset(){
      lcd->display("----");
      TIcon->setToolTip(NULL);
      lcdL->setText(tr("minutes"));
-     cal->setCalendarDate.setDate(QDate());
+     cal->setCalendarDate = QDateTime();
      cal->calendarDate.setDate(QDate());
-     cal->weekly->setEnabled(true);
-     cal->scrollAreaWidgetContents->setEnabled(true);
      showNormal();
      if(!ti->isActive())
        ti->start(30000);

--- a/qshutdown/src/ui/calendar.ui
+++ b/qshutdown/src/ui/calendar.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>Calendar</class>
  <widget class="QDialog" name="Calendar">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/qshutdown/src/ui/ch_passwd.ui
+++ b/qshutdown/src/ui/ch_passwd.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>ChangePassword</class>
  <widget class="QDialog" name="ChangePassword">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/qshutdown/src/ui/editor.ui
+++ b/qshutdown/src/ui/editor.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>Editor</class>
  <widget class="QDialog" name="Editor">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/qshutdown/src/ui/passwd.ui
+++ b/qshutdown/src/ui/passwd.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>PassWord</class>
  <widget class="QDialog" name="PassWord">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/qshutdown/src/ui/preferences.ui
+++ b/qshutdown/src/ui/preferences.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>Preferences</class>
  <widget class="QDialog" name="Preferences">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::WindowModal</enum>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
This PR fixes several issues with the Calendar/Weekly settings.

- Make windows modal to reduce confusing with open windows and the main window.
- Fix wrong behavior with calendar/weekly + not locking the main window settings.
- Fix unlock after disabling weekly setting.
- Fix discarding changes in calendar/weekly settings.
- Fix changing settings when locking is disabled in the main window.